### PR TITLE
feat: add cell interaction with events and dynamic styles

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,61 +1,49 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import Cell from "./components/Cell/Cell";
 
 const App = () => {
-  const [cellClicks, setCellClicks] = useState({
-    id: new Date(),
-    clicks: 1
-  })
-
-  const [pressTimeout, setPressTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
-
-
-  console.log(cellClicks);
-
-  const handlePlus = () => {
-    if (cellClicks.clicks < 5) {
-      setCellClicks(prev => ({ ...prev, clicks: prev.clicks + 1 }))
+  const [cellClicks, setCellClicks] = useState<{ id: number, clicks: number }[]>([
+    {
+      id: 1,
+      clicks: 1
+    },
+    {
+      id: 2,
+      clicks: 1
     }
-  }
+  ]);
 
-  const handleMinus = (e: any) => {
-    e.preventDefault()
-    if (cellClicks.clicks > 1) {
-      setCellClicks(prev => ({ ...prev, clicks: prev.clicks - 1 }))
+  const [isMouseDown, setIsMouseDown] = useState(false)
+  const [mouseButton, setMouseButton] = useState<number | null>(null)
+
+  useEffect(() => {
+    const handleMouseDown = (e: MouseEvent) => {
+      setIsMouseDown(true)
+      setMouseButton(e.button)
     }
-  }
 
-
-
-  const handleMouseDown = (e: React.MouseEvent) => {
-    const timeout = setTimeout(() => {
-      setCellClicks((prev) => ({
-        ...prev,
-        clicks: e.button === 0 ? 5 : 1
-      }))
-      setPressTimeout(null)
-    }, 1000)
-
-    setPressTimeout(timeout)
-  }
-
-  const handleMouseUp = () => {
-    if (pressTimeout) {
-      clearTimeout(pressTimeout)
-      setPressTimeout(null)
+    const handleMouseUp = () => {
+      setIsMouseDown(false)
+      setMouseButton(null)
     }
-  }
 
+    document.addEventListener("mousedown", handleMouseDown)
+    document.addEventListener("mouseup", handleMouseUp)
+
+    return () => {
+      document.removeEventListener("mousedown", handleMouseDown)
+      document.removeEventListener("mouseup", handleMouseUp)
+    }
+  }, [])
 
   return (
     <>
       Hello App!
       <Cell
-        handlePlus={handlePlus}
-        handleMinus={handleMinus}
-        handleMouseDown={handleMouseDown}
-        handleMouseUp={handleMouseUp}
         cellClicks={cellClicks}
+        setCellClicks={setCellClicks}
+        isMouseDown={isMouseDown}
+        mouseButton={mouseButton}
       />
     </>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,40 +1,11 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import Cell from "./components/Cell/Cell";
 
 const App = () => {
   const [cellClicks, setCellClicks] = useState<{ id: number, clicks: number }[]>([
-    {
-      id: 1,
-      clicks: 1
-    },
-    {
-      id: 2,
-      clicks: 1
-    }
+    { id: 1, clicks: 1 },
+    { id: 2, clicks: 1 }
   ]);
-
-  const [isMouseDown, setIsMouseDown] = useState(false)
-  const [mouseButton, setMouseButton] = useState<number | null>(null)
-
-  useEffect(() => {
-    const handleMouseDown = (e: MouseEvent) => {
-      setIsMouseDown(true)
-      setMouseButton(e.button)
-    }
-
-    const handleMouseUp = () => {
-      setIsMouseDown(false)
-      setMouseButton(null)
-    }
-
-    document.addEventListener("mousedown", handleMouseDown)
-    document.addEventListener("mouseup", handleMouseUp)
-
-    return () => {
-      document.removeEventListener("mousedown", handleMouseDown)
-      document.removeEventListener("mouseup", handleMouseUp)
-    }
-  }, [])
 
   return (
     <>
@@ -42,8 +13,6 @@ const App = () => {
       <Cell
         cellClicks={cellClicks}
         setCellClicks={setCellClicks}
-        isMouseDown={isMouseDown}
-        mouseButton={mouseButton}
       />
     </>
   )

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,62 @@
+import { useState } from "react";
 import Cell from "./components/Cell/Cell";
 
-const  App = () => {
+const App = () => {
+  const [cellClicks, setCellClicks] = useState({
+    id: new Date(),
+    clicks: 1
+  })
+
+  const [pressTimeout, setPressTimeout] = useState<ReturnType<typeof setTimeout> | null>(null);
+
+
+  console.log(cellClicks);
+
+  const handlePlus = () => {
+    if (cellClicks.clicks < 5) {
+      setCellClicks(prev => ({ ...prev, clicks: prev.clicks + 1 }))
+    }
+  }
+
+  const handleMinus = (e: any) => {
+    e.preventDefault()
+    if (cellClicks.clicks > 1) {
+      setCellClicks(prev => ({ ...prev, clicks: prev.clicks - 1 }))
+    }
+  }
+
+
+
+  const handleMouseDown = (e: React.MouseEvent) => {
+    const timeout = setTimeout(() => {
+      setCellClicks((prev) => ({
+        ...prev,
+        clicks: e.button === 0 ? 5 : 1
+      }))
+      setPressTimeout(null)
+    }, 1000)
+
+    setPressTimeout(timeout)
+  }
+
+  const handleMouseUp = () => {
+    if (pressTimeout) {
+      clearTimeout(pressTimeout)
+      setPressTimeout(null)
+    }
+  }
+
+
   return (
     <>
       Hello App!
-      <Cell />
+      <Cell
+        handlePlus={handlePlus}
+        handleMinus={handleMinus}
+        handleMouseDown={handleMouseDown}
+        handleMouseUp={handleMouseUp}
+        cellClicks={cellClicks}
+      />
     </>
   )
 }

--- a/src/components/Cell/Cell.module.scss
+++ b/src/components/Cell/Cell.module.scss
@@ -1,8 +1,23 @@
+@use "sass:map";
+
+$cell-colors: (
+    1: (background: #161b22, border: #171b22),
+    2: (background: #0e4429, border: #1a4e34),
+    3: (background: #006d32, border: #0d743c),
+    4: (background: #26a641, border: #31ab4b),
+    5: (background: #39d353, border: #43d55c)
+);
+
 .cell {
-    border: solid 1px black;
     width: 50px;
     aspect-ratio: 1;
-    background-color: #39d353;
     border-radius: 5px;
     cursor: pointer;
+}
+
+@for $i from 1 through 5 {
+    .cell.level-#{$i} {
+        background-color: map.get(map.get($cell-colors, $i), background);
+        border: 2px solid map.get(map.get($cell-colors, $i), border);
+    }
 }

--- a/src/components/Cell/Cell.module.scss
+++ b/src/components/Cell/Cell.module.scss
@@ -9,15 +9,17 @@ $cell-colors: (
 );
 
 .cell {
-    width: 50px;
+    width: 10px;
     aspect-ratio: 1;
-    border-radius: 5px;
+    border-radius: 2px;
+    opacity: .5;
+    outline-offset: -1px;
     cursor: pointer;
 }
 
 @for $i from 1 through 5 {
     .cell.level-#{$i} {
         background-color: map.get(map.get($cell-colors, $i), background);
-        border: 2px solid map.get(map.get($cell-colors, $i), border);
+        outline: 1px solid map.get(map.get($cell-colors, $i), border);
     }
 }

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -1,9 +1,16 @@
 import styles from "./Cell.module.scss";
 
-const Cell = () => {
-    return(
-        <div className={styles.cell}>
-            aaaa
+const Cell = ({ handlePlus, handleMinus, cellClicks, handleMouseDown, handleMouseUp }: any) => {
+    console.log(String(cellClicks.clicks));
+
+    return (
+        <div
+            className={`${styles.cell} ${styles[`level-${String(cellClicks.clicks)}`]}`}
+            onClick={handlePlus}
+            onContextMenu={handleMinus}
+            onMouseDown={handleMouseDown}
+            onMouseUp={handleMouseUp}
+        >
         </div>
     )
 }

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -1,17 +1,56 @@
 import styles from "./Cell.module.scss";
 
-const Cell = ({ handlePlus, handleMinus, cellClicks, handleMouseDown, handleMouseUp }: any) => {
-    console.log(String(cellClicks.clicks));
+const Cell = ({ cellClicks, setCellClicks, isMouseDown, mouseButton }: {
+    cellClicks: { id: number; clicks: number }[]
+    setCellClicks: React.Dispatch<React.SetStateAction<{ id: number; clicks: number }[]>>
+    isMouseDown: boolean
+    mouseButton: number | null
+}) => {
+
+    const updateCellClicks = (id: number, action: "increment" | "decrement") => {
+        setCellClicks((prev) =>
+            prev.map((cell) =>
+                cell.id === id
+                    ? {
+                        ...cell,
+                        clicks:
+                            action === "increment" && cell.clicks < 5
+                                ? cell.clicks + 1
+                                : action === "decrement" && cell.clicks > 1
+                                    ? cell.clicks - 1
+                                    : cell.clicks
+                    }
+                    : cell
+            )
+        )
+    }
+
+    const handleLeftClick = (id: number) => updateCellClicks(id, "increment");
+
+    const handleRightClick = (e: React.MouseEvent, id: number) => {
+        e.preventDefault()
+        updateCellClicks(id, "decrement")
+    }
+
+    const handleMouseEnter = (id: number) => {
+        if (!isMouseDown || mouseButton === null) return
+        if (mouseButton === 0) updateCellClicks(id, "increment")
+        if (mouseButton === 2) updateCellClicks(id, "decrement")
+    }
 
     return (
-        <div
-            className={`${styles.cell} ${styles[`level-${String(cellClicks.clicks)}`]}`}
-            onClick={handlePlus}
-            onContextMenu={handleMinus}
-            onMouseDown={handleMouseDown}
-            onMouseUp={handleMouseUp}
-        >
-        </div>
+        <>
+            {cellClicks.map((cell) =>
+                <div
+                    key={cell.id}
+                    className={`${styles.cell} ${styles[`level-${String(cell.clicks)}`]}`}
+                    onClick={() => handleLeftClick(cell.id)}
+                    onContextMenu={(e) => handleRightClick(e, cell.id)}
+                    onMouseEnter={() => handleMouseEnter(cell.id)}
+                >
+                </div>
+            )}
+        </>
     )
 }
 

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -1,11 +1,40 @@
+import { useEffect, useState } from "react";
 import styles from "./Cell.module.scss";
 
-const Cell = ({ cellClicks, setCellClicks, isMouseDown, mouseButton }: {
-    cellClicks: { id: number; clicks: number }[]
+interface CellProps {
+    id: number
+    clicks: number
+}
+
+interface CellComponentProps {
+    cellClicks: CellProps[]
     setCellClicks: React.Dispatch<React.SetStateAction<{ id: number; clicks: number }[]>>
-    isMouseDown: boolean
-    mouseButton: number | null
-}) => {
+}
+
+const Cell = ({ cellClicks, setCellClicks }: CellComponentProps) => {
+
+    const [isMouseDown, setIsMouseDown] = useState(false)
+    const [mouseButton, setMouseButton] = useState<number | null>(null)
+
+    useEffect(() => {
+        const handleMouseDown = (e: MouseEvent) => {
+            setIsMouseDown(true)
+            setMouseButton(e.button)
+        }
+
+        const handleMouseUp = () => {
+            setIsMouseDown(false)
+            setMouseButton(null)
+        }
+
+        document.addEventListener("mousedown", handleMouseDown)
+        document.addEventListener("mouseup", handleMouseUp)
+
+        return () => {
+            document.removeEventListener("mousedown", handleMouseDown)
+            document.removeEventListener("mouseup", handleMouseUp)
+        }
+    }, [])
 
     const updateCellClicks = (id: number, action: "increment" | "decrement") => {
         setCellClicks((prev) =>
@@ -34,22 +63,23 @@ const Cell = ({ cellClicks, setCellClicks, isMouseDown, mouseButton }: {
 
     const handleMouseEnter = (id: number) => {
         if (!isMouseDown || mouseButton === null) return
-        if (mouseButton === 0) updateCellClicks(id, "increment")
-        if (mouseButton === 2) updateCellClicks(id, "decrement")
+
+        if (mouseButton === 0) {
+            updateCellClicks(id, "increment")
+        } else if (mouseButton === 2) {
+            updateCellClicks(id, "decrement")
+        }
     }
 
     return (
         <>
-            {cellClicks.map((cell) =>
-                <div
-                    key={cell.id}
-                    className={`${styles.cell} ${styles[`level-${String(cell.clicks)}`]}`}
-                    onClick={() => handleLeftClick(cell.id)}
-                    onContextMenu={(e) => handleRightClick(e, cell.id)}
-                    onMouseEnter={() => handleMouseEnter(cell.id)}
-                >
-                </div>
-            )}
+            <div
+                className={`${styles.cell} ${styles[`level-${String(cellClicks[1].clicks)}`]}`}
+                onClick={() => handleLeftClick(cellClicks[1].id)}
+                onContextMenu={(e) => handleRightClick(e, cellClicks[1].id)}
+                onMouseEnter={() => handleMouseEnter(cellClicks[1].id)}
+            >
+            </div>
         </>
     )
 }

--- a/src/components/Cell/Cell.tsx
+++ b/src/components/Cell/Cell.tsx
@@ -3,6 +3,7 @@ import styles from "./Cell.module.scss";
 const Cell = () => {
     return(
         <div className={styles.cell}>
+            aaaa
         </div>
     )
 }


### PR DESCRIPTION
## feat: add cell interaction with events and dynamic styles  

### Changes introduced:  
- Implemented **click interactions** for the cell, limiting clicks between `1` and `5`.  
- Added **event handlers** for:  
  - **Left-click** (`onClick`) → Increases the level (max `5`).  
  - **Right-click** (`onContextMenu`) → Decreases the level (min `1`).  
  - **Mouse hold** (`onMouseDown`) → Instantly sets to `5` (left) or `1` (right) after `1s`.  
- Applied **dynamic styles** to visually represent click levels using SCSS.  